### PR TITLE
Go to beginning of line before updating indentation

### DIFF
--- a/kdl-mode.el
+++ b/kdl-mode.el
@@ -175,7 +175,7 @@
   (let ((pos (- (point-max) (point)))
         (indent (or indent (kdl-calculate-indentation)))
         (shift-amount nil)
-        (beg (line-beginning-position)))
+        (beg (progn (beginning-of-line) (point))))
     (skip-chars-forward " \t")
     (if (null indent)
         (goto-char (- (point-max) pos))


### PR DESCRIPTION
This prevents deletion of text on the line when indenting.

This reverts commit 3e88553c05bf9ed5fa8ac0797e545ea67316677f.
